### PR TITLE
Fix layout of card body

### DIFF
--- a/src/lib/Card/Card.scss
+++ b/src/lib/Card/Card.scss
@@ -104,6 +104,7 @@
     display: flex;
     flex-direction: column;
     margin: 0 $spacing__m;
+    flex-grow: 1;
     order: 2;
   }
 


### PR DESCRIPTION
card body needs `flex-grow: 1` so that it fills the center of the card and the image and cta float the left and right.