### PR TITLE
Fix - Container Query Support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4rena/components-library",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Code4rena's official components library ",
   "types": "./dist/lib.d.ts",
   "exports": {

--- a/src/lib/ContestTile/ContestTile.tsx
+++ b/src/lib/ContestTile/ContestTile.tsx
@@ -10,7 +10,6 @@ import { Status } from "../ContestStatus/ContestStatus.types";
 import {
   formatDistanceToNow,
   formatDistanceToNowStrict,
-  isBefore,
 } from "date-fns";
 import "./ContestTile.scss";
 import CompactTemplate from "./CompactTemplate";
@@ -158,6 +157,19 @@ export const ContestTile: React.FC<ContestTileProps> = ({
   description,
 }) => {
   const isDefault = variant === ContestTileVariant.DARK || variant === ContestTileVariant.LIGHT;
+
+  useEffect(() => {
+    // Loads polyfill to support container queries in older browsers.
+    const loadContainerQueryPolyfill = () => {
+      const supportsContainerQueries = "container" in document.documentElement.style;
+      if (!supportsContainerQueries) {
+        // @ts-ignore
+        import("container-query-polyfill");
+      }
+    }
+
+    loadContainerQueryPolyfill();
+  }, []);
 
   return (isDefault 
     ? <DefaultTemplate


### PR DESCRIPTION
This PR is for adding container query support for older browsers.

Currently, the contest tile uses container queries instead of media queries; while it is already widely supported at this point, this properly implements the `container-query-polyfill` to make sure that container queries work in older browsers that do not support it. This ensures that our component looks exactly as intended in older browsers.

