### PR TITLE
Use presence of bot race findings repo to determine if there is a bot race

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4rena/components-library",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Code4rena's official components library ",
   "types": "./dist/lib.d.ts",
   "exports": {

--- a/src/lib/ContestTile/ContestTile.types.ts
+++ b/src/lib/ContestTile/ContestTile.types.ts
@@ -53,6 +53,8 @@ export interface ContestTileData {
   contestRepo: string;
   /** Absolute url to the contest's findings. */
   findingsRepo: string;
+  /** Absolute url to the contest's findings. */
+  botFindingsRepo?: string;
   /** Reward pool for the current contest. */
   amount: string;
   /** Callback function to be triggered on contest time/status changes. */

--- a/src/lib/ContestTile/DefaultTemplate.tsx
+++ b/src/lib/ContestTile/DefaultTemplate.tsx
@@ -58,26 +58,35 @@ export default function DefaultTemplate({
     }, [bountyData])
 
     useEffect(() => {
-        if (bountyData && bountyData.startDate) {
-          const newTimelineObject = getDates(bountyData.startDate, "2999-01-01T00:00:00Z");
-          setBountyTimelineObject(newTimelineObject);
+      if (bountyData && bountyData.startDate) {
+        const newTimelineObject = getDates(
+          bountyData.startDate,
+          "2999-01-01T00:00:00Z"
+        );
+        setBountyTimelineObject(newTimelineObject);
+      }
+
+      if (contestData) {
+        setHasBotRace(!!contestData.botFindingsRepo);
+        if (contestData.startDate && contestData.endDate) {
+          const newTimelineObject = getDates(
+            contestData.startDate,
+            contestData.endDate
+          );
+          setContestTimelineObject(newTimelineObject);
         }
 
-        if (contestData) {
-            setHasBotRace(contestData.codeAccess === "public");
-            if (contestData.startDate && contestData.endDate) {
-              const newTimelineObject = getDates(contestData.startDate, contestData.endDate);
-              setContestTimelineObject(newTimelineObject);
-            }
-
-            if (contestData.codeAccess === "public") {
-              setCanViewContest(true);
-            } else if (contestData.codeAccess === "certified" && contestData.isUserCertified) {
-              setCanViewContest(true);
-            } else {
-              setCanViewContest(false);
-            }
+        if (contestData.codeAccess === "public") {
+          setCanViewContest(true);
+        } else if (
+          contestData.codeAccess === "certified" &&
+          contestData.isUserCertified
+        ) {
+          setCanViewContest(true);
+        } else {
+          setCanViewContest(false);
         }
+      }
     }, [contestData])
 
     useEffect(() => {


### PR DESCRIPTION
Some public contests do not have bot races, so we use the presence of a bot race findings repo as a signal for whether or not the contest has a bot race. This is a hotfix because we currently have an upcoming contest which should not have a bot race, but which is showing the bot race indicator.