### PR TITLE
Contest Tile: Add support for Rolling Triage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@code4rena/components-library",
-  "version": "4.1.0",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@code4rena/components-library",
-      "version": "4.1.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
         "clsx": "^1.2.1",

--- a/src/lib/ContestStatus/ContestStatus.types.ts
+++ b/src/lib/ContestStatus/ContestStatus.types.ts
@@ -12,3 +12,21 @@ export interface ContestStatusProps {
   /** HTML element identifier */
   id?: string;
 }
+
+export const AuditStatus = {
+  Booking: "Booking",
+  PreAudit: "Pre-Audit",
+  Active: "Active",
+  /** Paused: The audit is in between Rolling Triage cohorts */
+  Paused: "Paused",
+  Review: "Review",
+  Judging: "Judging",
+  PJQA: "Post-Judging QA",
+  JudgingComplete: "Judging Complete",
+  Awarding: "Awarding",
+  Reporting: "Reporting",
+  Completed: "Completed",
+  LostDeal: "Lost Deal",
+} as const;
+// Take the AuditStatus object, and make a string literal type of the values
+export type AuditStatus = (typeof AuditStatus)[keyof typeof AuditStatus];

--- a/src/lib/ContestTile/CompactTemplate.tsx
+++ b/src/lib/ContestTile/CompactTemplate.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 import { BountyTileData, ContestSchedule, ContestTileData, ContestTileProps, ContestTileVariant } from "./ContestTile.types";
 import { Status, TagSize, TagVariant } from '../types';
 import { ContestStatus } from '../ContestStatus';
-import { Countdown } from './ContestTile';
+import { ContestCountdown } from './ContestTile';
 import { getDates } from '../../utils/time';
 import { Tag } from '../Tag';
 import { Icon } from '../Icon';
@@ -28,7 +28,7 @@ export default function CompactTemplate({
       c4contesttile: true,
       compact: true
     });
-      
+
     return <div className={clsx("c4tilewrapper", variantClasses)}>
       <div id={htmlId ?? undefined} className={clsx(variantClasses, tileClasses)}>
         <div className="container--inner compact-content">
@@ -82,7 +82,7 @@ const IsContest = ({title, isDarkTile = true, contestData, sponsorUrl, sponsorIm
       }
 
       if (startDate && endDate) {
-        const newTimelineObject = getDates(contestData.startDate, contestData.endDate);
+        const newTimelineObject = getDates(contestData.startDate, contestData.endDate, contestData.cohorts);
         setContestTimelineObject(newTimelineObject);
       }
     }
@@ -90,7 +90,7 @@ const IsContest = ({title, isDarkTile = true, contestData, sponsorUrl, sponsorIm
 
   useEffect(() => {
     if (contestData && startDate && endDate) {
-      const newTimelineObject = getDates(startDate, endDate);
+      const newTimelineObject = getDates(startDate, endDate, contestData.cohorts);
       setContestTimelineObject(newTimelineObject);
     }
   }, [contestData])
@@ -104,14 +104,12 @@ const IsContest = ({title, isDarkTile = true, contestData, sponsorUrl, sponsorIm
               status={contestTimelineObject.contestStatus} />
             {contestTimelineObject.contestStatus !== Status.ENDED && (
               <div className="timer">
-                <Countdown
-                  start={startDate}
-                  end={endDate}
+                <ContestCountdown
+                  schedule={contestTimelineObject}
                   updateContestStatus={updateContestTileStatus}
-                  text={contestTimelineObject.contestStatus === Status.UPCOMING ? 'Starts in ' : 'Ends in '}
                 />
               </div>
-            )}  
+            )}
           </span>}
           <p className="type">
             {contestType === "Audit + mitigation review"
@@ -208,7 +206,7 @@ const IsBounty = ({title, isDarkTile = true, bountyData, sponsorUrl, sponsorImag
         break;
     }
   }
-  
+
   return (
     <div className="body--bounty">
       <header>

--- a/src/lib/ContestTile/CompactTemplate.tsx
+++ b/src/lib/ContestTile/CompactTemplate.tsx
@@ -4,7 +4,7 @@ import { BountyTileData, ContestSchedule, ContestTileData, ContestTileProps, Con
 import { Status, TagSize, TagVariant } from '../types';
 import { ContestStatus } from '../ContestStatus';
 import { ContestCountdown } from './ContestTile';
-import { getDates } from '../../utils/time';
+import { getContestSchedule } from '../../utils/time';
 import { Tag } from '../Tag';
 import { Icon } from '../Icon';
 import wolfbotIcon from "../../../public/icons/wolfbot.svg";
@@ -82,7 +82,7 @@ const IsContest = ({title, isDarkTile = true, contestData, sponsorUrl, sponsorIm
       }
 
       if (startDate && endDate) {
-        const newTimelineObject = getDates(contestData.startDate, contestData.endDate, contestData.cohorts);
+        const newTimelineObject = getContestSchedule(contestData);
         setContestTimelineObject(newTimelineObject);
       }
     }
@@ -90,7 +90,7 @@ const IsContest = ({title, isDarkTile = true, contestData, sponsorUrl, sponsorIm
 
   useEffect(() => {
     if (contestData && startDate && endDate) {
-      const newTimelineObject = getDates(startDate, endDate, contestData.cohorts);
+      const newTimelineObject = getContestSchedule(contestData);
       setContestTimelineObject(newTimelineObject);
     }
   }, [contestData])

--- a/src/lib/ContestTile/ContestTile.stories.tsx
+++ b/src/lib/ContestTile/ContestTile.stories.tsx
@@ -3,6 +3,7 @@ import { addDays, subDays } from "date-fns";
 import { ContestTile } from "./ContestTile";
 import { Meta, StoryObj } from "@storybook/react";
 import { CodingLanguage, ContestEcosystem, ContestTileVariant } from "./ContestTile.types";
+import { AuditStatus } from "../types";
 
 const meta: Meta<typeof ContestTile> = {
   component: ContestTile,
@@ -151,7 +152,7 @@ export const ContestTileLivePreCohort2: Story = (args) => {
     />
   </Fragment>
 };
-export const ContestTileLiveCohort3: Story = (args) => {
+export const ContestTileLiveAwaitingCohort3: Story = (args) => {
   const isDark = args.variant === ContestTileVariant.DARK || args.variant === ContestTileVariant.COMPACT_DARK;
 
   return <Fragment>
@@ -207,7 +208,7 @@ ContestTileUpcomingRollingTriage.parameters = parameters;
 ContestTileLive.parameters = parameters;
 ContestTileLiveCohort1.parameters = parameters;
 ContestTileLivePreCohort2.parameters = parameters;
-ContestTileLiveCohort3.parameters = parameters;
+ContestTileLiveAwaitingCohort3.parameters = parameters;
 ContestTileEnded.parameters = parameters;
 BountyTile.parameters = parameters;
 
@@ -216,7 +217,8 @@ ContestTileUpcoming.args = {
   contestData: {
     ...defaultArgs.contestData,
     startDate: "2030-07-12T18:00:00Z",
-    endDate: "2030-07-21T18:00:00.000Z"
+    endDate: "2030-07-21T18:00:00.000Z",
+    status: AuditStatus.PreAudit,
   }
 };
 ContestTileUpcomingRollingTriage.args = {
@@ -238,6 +240,7 @@ ContestTileUpcomingRollingTriage.args = {
     }],
     startDate: addDays(Date.now(), 3).toISOString(),
     endDate: addDays(Date.now(), 20).toISOString(),
+    status: AuditStatus.PreAudit,
   }
 };
 
@@ -247,7 +250,8 @@ ContestTileLive.args = {
   contestData: {
     ...defaultArgs.contestData,
     startDate: "2023-07-12T18:00:00Z",
-    endDate: "2030-07-21T18:00:00.000Z"
+    endDate: "2030-07-21T18:00:00.000Z",
+    status: AuditStatus.Active,
   }
 };
 ContestTileLiveCohort1.args = {
@@ -269,6 +273,7 @@ ContestTileLiveCohort1.args = {
     }],
     startDate: subDays(Date.now(), 1).toISOString(),
     endDate: addDays(Date.now(), 18).toISOString(),
+    status: AuditStatus.Active,
   }
 };
 ContestTileLivePreCohort2.args = {
@@ -290,9 +295,10 @@ ContestTileLivePreCohort2.args = {
     }],
     startDate: subDays(Date.now(), 6).toISOString(),
     endDate: addDays(Date.now(), 16).toISOString(),
+    status: AuditStatus.Paused,
   }
 };
-ContestTileLiveCohort3.args = {
+ContestTileLiveAwaitingCohort3.args = {
   ...defaultArgs,
   contestData: {
     ...defaultArgs.contestData,
@@ -311,6 +317,7 @@ ContestTileLiveCohort3.args = {
     }],
     startDate: subDays(Date.now(), 16).toISOString(),
     endDate: addDays(Date.now(), 6).toISOString(),
+    status: AuditStatus.Paused,
   }
 };
 
@@ -319,7 +326,8 @@ ContestTileEnded.args = {
   contestData: {
     ...defaultArgs.contestData,
     startDate: "2023-07-12T18:00:00Z",
-    endDate: "2023-07-21T18:00:00Z"
+    endDate: "2023-07-21T18:00:00Z",
+    status: AuditStatus.Review,
   }
 };
 

--- a/src/lib/ContestTile/ContestTile.stories.tsx
+++ b/src/lib/ContestTile/ContestTile.stories.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from "react";
+import { addDays, subDays } from "date-fns";
 import { ContestTile } from "./ContestTile";
 import { Meta, StoryObj } from "@storybook/react";
 import { CodingLanguage, ContestEcosystem, ContestTileVariant } from "./ContestTile.types";
@@ -36,6 +37,7 @@ const defaultArgs = {
   htmlId: "",
   contestData: {
     codeAccess: "public",
+    cohorts: [],
     contestType: "Open Audit",
     isUserCertified: false,
     contestId: 321,
@@ -75,7 +77,81 @@ export const ContestTileUpcoming: Story = (args) => {
   </Fragment>
 };
 
+export const ContestTileUpcomingRollingTriage: Story = (args) => {
+  const isDark = args.variant === ContestTileVariant.DARK || args.variant === ContestTileVariant.COMPACT_DARK;
+
+  return <Fragment>
+    <ContestTile
+      {...args}
+      variant={isDark ? ContestTileVariant.DARK : ContestTileVariant.LIGHT}
+      startDate={new Date(args.contestData.startDate).toISOString()}
+      endDate={new Date(args.contestData.endDate).toISOString()}
+    />
+    <ContestTile
+      {...args}
+      variant={isDark ? ContestTileVariant.COMPACT_DARK : ContestTileVariant.COMPACT_LIGHT }
+      startDate={new Date(args.contestData.startDate).toISOString()}
+      endDate={new Date(args.contestData.endDate).toISOString()}
+    />
+  </Fragment>
+};
+
 export const ContestTileLive: Story = (args) => {
+  const isDark = args.variant === ContestTileVariant.DARK || args.variant === ContestTileVariant.COMPACT_DARK;
+
+  return <Fragment>
+    <ContestTile
+      {...args}
+      variant={isDark ? ContestTileVariant.DARK : ContestTileVariant.LIGHT}
+      startDate={new Date(args.contestData.startDate).toISOString()}
+      endDate={new Date(args.contestData.endDate).toISOString()}
+    />
+    <ContestTile
+      {...args}
+      variant={isDark ? ContestTileVariant.COMPACT_DARK : ContestTileVariant.COMPACT_LIGHT }
+      startDate={new Date(args.contestData.startDate).toISOString()}
+      endDate={new Date(args.contestData.endDate).toISOString()}
+    />
+  </Fragment>
+};
+
+export const ContestTileLiveCohort1: Story = (args) => {
+  const isDark = args.variant === ContestTileVariant.DARK || args.variant === ContestTileVariant.COMPACT_DARK;
+
+  return <Fragment>
+    <ContestTile
+      {...args}
+      variant={isDark ? ContestTileVariant.DARK : ContestTileVariant.LIGHT}
+      startDate={new Date(args.contestData.startDate).toISOString()}
+      endDate={new Date(args.contestData.endDate).toISOString()}
+    />
+    <ContestTile
+      {...args}
+      variant={isDark ? ContestTileVariant.COMPACT_DARK : ContestTileVariant.COMPACT_LIGHT }
+      startDate={new Date(args.contestData.startDate).toISOString()}
+      endDate={new Date(args.contestData.endDate).toISOString()}
+    />
+  </Fragment>
+};
+export const ContestTileLivePreCohort2: Story = (args) => {
+  const isDark = args.variant === ContestTileVariant.DARK || args.variant === ContestTileVariant.COMPACT_DARK;
+
+  return <Fragment>
+    <ContestTile
+      {...args}
+      variant={isDark ? ContestTileVariant.DARK : ContestTileVariant.LIGHT}
+      startDate={new Date(args.contestData.startDate).toISOString()}
+      endDate={new Date(args.contestData.endDate).toISOString()}
+    />
+    <ContestTile
+      {...args}
+      variant={isDark ? ContestTileVariant.COMPACT_DARK : ContestTileVariant.COMPACT_LIGHT }
+      startDate={new Date(args.contestData.startDate).toISOString()}
+      endDate={new Date(args.contestData.endDate).toISOString()}
+    />
+  </Fragment>
+};
+export const ContestTileLiveCohort3: Story = (args) => {
   const isDark = args.variant === ContestTileVariant.DARK || args.variant === ContestTileVariant.COMPACT_DARK;
 
   return <Fragment>
@@ -127,7 +203,11 @@ export const BountyTile: Story = (args) => {
 }
 
 ContestTileUpcoming.parameters = parameters;
+ContestTileUpcomingRollingTriage.parameters = parameters;
 ContestTileLive.parameters = parameters;
+ContestTileLiveCohort1.parameters = parameters;
+ContestTileLivePreCohort2.parameters = parameters;
+ContestTileLiveCohort3.parameters = parameters;
 ContestTileEnded.parameters = parameters;
 BountyTile.parameters = parameters;
 
@@ -139,6 +219,28 @@ ContestTileUpcoming.args = {
     endDate: "2030-07-21T18:00:00.000Z"
   }
 };
+ContestTileUpcomingRollingTriage.args = {
+  ...defaultArgs,
+  contestData: {
+    ...defaultArgs.contestData,
+    cohorts: [{
+      name: "cohort-1",
+      pauseTime: addDays(Date.now(), 6).toISOString(),
+      resumeTime: null
+    }, {
+      name: "cohort-2",
+      pauseTime: addDays(Date.now(), 13).toISOString(),
+      resumeTime: addDays(Date.now(), 9).toISOString(),
+    }, {
+      name: "cohort-3",
+      pauseTime: null,
+      resumeTime: addDays(Date.now(), 16).toISOString(),
+    }],
+    startDate: addDays(Date.now(), 3).toISOString(),
+    endDate: addDays(Date.now(), 20).toISOString(),
+  }
+};
+
 
 ContestTileLive.args = {
   ...defaultArgs,
@@ -146,6 +248,69 @@ ContestTileLive.args = {
     ...defaultArgs.contestData,
     startDate: "2023-07-12T18:00:00Z",
     endDate: "2030-07-21T18:00:00.000Z"
+  }
+};
+ContestTileLiveCohort1.args = {
+  ...defaultArgs,
+  contestData: {
+    ...defaultArgs.contestData,
+    cohorts: [{
+      name: "cohort-1",
+      pauseTime: addDays(Date.now(), 4).toISOString(),
+      resumeTime: null
+    }, {
+      name: "cohort-2",
+      pauseTime: addDays(Date.now(), 11).toISOString(),
+      resumeTime: addDays(Date.now(), 7).toISOString(),
+    }, {
+      name: "cohort-3",
+      pauseTime: null,
+      resumeTime: addDays(Date.now(), 14).toISOString(),
+    }],
+    startDate: subDays(Date.now(), 1).toISOString(),
+    endDate: addDays(Date.now(), 18).toISOString(),
+  }
+};
+ContestTileLivePreCohort2.args = {
+  ...defaultArgs,
+  contestData: {
+    ...defaultArgs.contestData,
+    cohorts: [{
+      name: "cohort-1",
+      pauseTime: subDays(Date.now(), 1).toISOString(),
+      resumeTime: null
+    }, {
+      name: "cohort-2",
+      pauseTime: addDays(Date.now(), 6).toISOString(),
+      resumeTime: addDays(Date.now(), 2).toISOString(),
+    }, {
+      name: "cohort-3",
+      pauseTime: null,
+      resumeTime: addDays(Date.now(), 9).toISOString(),
+    }],
+    startDate: subDays(Date.now(), 6).toISOString(),
+    endDate: addDays(Date.now(), 16).toISOString(),
+  }
+};
+ContestTileLiveCohort3.args = {
+  ...defaultArgs,
+  contestData: {
+    ...defaultArgs.contestData,
+    cohorts: [{
+      name: "cohort-1",
+      pauseTime: subDays(Date.now(), 11).toISOString(),
+      resumeTime: null
+    }, {
+      name: "cohort-2",
+      pauseTime: subDays(Date.now(), 4).toISOString(),
+      resumeTime: subDays(Date.now(), 8).toISOString(),
+    }, {
+      name: "cohort-3",
+      pauseTime: null,
+      resumeTime: subDays(Date.now(), 1).toISOString(),
+    }],
+    startDate: subDays(Date.now(), 16).toISOString(),
+    endDate: addDays(Date.now(), 6).toISOString(),
   }
 };
 

--- a/src/lib/ContestTile/ContestTile.tsx
+++ b/src/lib/ContestTile/ContestTile.tsx
@@ -138,7 +138,7 @@ export const ContestCountdown = ({
     text = "Starts in ";
   } else if (schedule.contestStatus === Status.LIVE) {
     if (schedule.resume && +schedule.resume >= Date.now()) {
-      text = "Cohort resumes in ";
+      text = "Cohort tentatively resumes in ";
       start = schedule.resume.toISOString();
     } else if (schedule.pause && +schedule.pause >= Date.now()) {
       text = "Cohort pauses in ";

--- a/src/lib/ContestTile/ContestTile.tsx
+++ b/src/lib/ContestTile/ContestTile.tsx
@@ -57,7 +57,7 @@ export const Countdown = ({
   }
 
   const countDown = useCallback(() => {
-    const newTimer = getDates(start, end);
+    const newTimer = getDates(start, end, []);
     const target = getCountdownTarget(newTimer);
     // Get total number of seconds remaining
     const totalSeconds = formatDistanceToNowStrict(target, {
@@ -78,7 +78,7 @@ export const Countdown = ({
   useEffect(() => {
     const timer = setInterval(
       () => {
-        const newTimer = getDates(start, end);
+        const newTimer = getDates(start, end, []);
         if (
           contestTimer &&
           (contestTimer.contestStatus !== newTimer.contestStatus ||
@@ -122,6 +122,35 @@ export const Countdown = ({
       <span>{formattedCountdown}</span>
     </div>
   );
+};
+
+export const ContestCountdown = ({
+  schedule,
+  updateContestStatus
+}: {
+  schedule: ContestSchedule,
+  updateContestStatus: CountdownProps["updateContestStatus"]
+}) => {
+  let text = "Ends in ";
+  let start = schedule.start.toISOString();
+  let end = schedule.end.toISOString();
+  if (schedule.contestStatus === Status.UPCOMING) {
+    text = "Starts in ";
+  } else if (schedule.contestStatus === Status.LIVE) {
+    if (schedule.resume && +schedule.resume >= Date.now()) {
+      text = "Cohort resumes in ";
+      start = schedule.resume.toISOString();
+    } else if (schedule.pause && +schedule.pause >= Date.now()) {
+      text = "Cohort pauses in ";
+      end = schedule.pause.toISOString();
+    }
+  }
+  return Countdown({
+    start,
+    end,
+    text,
+    updateContestStatus,
+  });
 };
 
 /**

--- a/src/lib/ContestTile/ContestTile.tsx
+++ b/src/lib/ContestTile/ContestTile.tsx
@@ -138,17 +138,17 @@ export const ContestCountdown = ({
     text = "Starts in ";
   } else if (schedule.contestStatus === Status.LIVE) {
     if (schedule.status === AuditStatus.Paused && schedule.resume && +schedule.resume >= Date.now()) {
-      text = "Next cohort starts in ";
+      text = "Next submission phase starts in ";
       start = schedule.resume.toISOString();
     } else if (schedule.status === AuditStatus.Paused && schedule.resume && +schedule.resume <= Date.now()) {
       // The resume time has elapsed, give a generic time for now
       return (
         <div className="countdown">
-          {"Next cohort starts soon"}
+          Next submission phase starts soon
         </div>
       );
     } else if (schedule.status === AuditStatus.Active && schedule.pause && +schedule.pause >= Date.now()) {
-      text = "Current cohort ends in ";
+      text = "Current submission phase ends in ";
       end = schedule.pause.toISOString();
     }
   }

--- a/src/lib/ContestTile/ContestTile.types.ts
+++ b/src/lib/ContestTile/ContestTile.types.ts
@@ -12,6 +12,12 @@ export type ContestEcosystem = "Algorand" | "Aptos" | "Blast" | "Cosmos" | "EVM"
 
 export type CodingLanguage = "Cairo" | "GO" | "HUFF" | "Ink" | "Move" | "Noir" | "Other" | "Rain" | "Rust" | "Rust evm" | "Solidity" | "Vyper" | "Yul";
 
+export interface ContestCohort {
+  resumeTime: string | null;
+  pauseTime: string | null;
+  name: string;
+}
+
 export interface ContestTileProps {
   /** An html `id` for the contest tile's wrapping div. */
   htmlId?: string;
@@ -53,6 +59,8 @@ export interface BountyTileData {
 export interface ContestTileData {
   /** String indicating required access for viewing contest. */
   codeAccess: string;
+  /** Array of cohorts for Rolling Triage audits. Empty for normal audits */
+  cohorts: ContestCohort[];
   /** String indicating a specific categorization for the current contest. */
   contestType?: string;
   /** Unique numerical identifier for the current contest. */
@@ -86,6 +94,10 @@ export interface ContestSchedule {
   botRaceStatus?: Status;
   start: Date;
   end: Date;
+  /** The time the current cohort will pause. */
+  pause: Date | null;
+  /** The time the current cohort will resume. */
+  resume: Date | null;
   botRaceEnd: Date;
   formattedStart: string;
   formattedEnd: string;

--- a/src/lib/ContestTile/ContestTile.types.ts
+++ b/src/lib/ContestTile/ContestTile.types.ts
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { Status } from "../ContestStatus/ContestStatus.types";
+import { Status, AuditStatus } from "../ContestStatus/ContestStatus.types";
 
 export enum ContestTileVariant {
   LIGHT = "LIGHT",
@@ -87,23 +87,29 @@ export interface ContestTileData {
   endDate: string;
   /** Boolean indicating certification status of logged in user. Required for viewing certain contests. */
   isUserCertified: boolean;
+  status: AuditStatus;
 }
 
-export interface ContestSchedule {
+export interface BaseContestSchedule {
   contestStatus?: Status;
   botRaceStatus?: Status;
   start: Date;
   end: Date;
-  /** The time the current cohort will pause. */
-  pause: Date | null;
-  /** The time the current cohort will resume. */
-  resume: Date | null;
   botRaceEnd: Date;
   formattedStart: string;
   formattedEnd: string;
   timeZone: string;
   formattedBotRaceEnd: string;
   formattedDuration: string;
+}
+
+export interface ContestSchedule extends BaseContestSchedule {
+  status: AuditStatus;
+  end: Date;
+  /** The time the current cohort will pause. */
+  pause: Date | null;
+  /** The time the current cohort will resume. */
+  resume: Date | null;
 }
 
 export interface CountdownProps {

--- a/src/lib/ContestTile/DefaultTemplate.tsx
+++ b/src/lib/ContestTile/DefaultTemplate.tsx
@@ -4,7 +4,7 @@ import wolfbotIcon from "../../../public/icons/wolfbot.svg";
 import { BountyTileData, ContestSchedule, ContestTileData, ContestTileProps, ContestTileVariant } from "./ContestTile.types";
 import { DropdownLink, Status, TagSize, TagVariant } from "../types";
 import { ContestStatus } from "../ContestStatus";
-import { Countdown } from "./ContestTile";
+import { ContestCountdown, Countdown } from "./ContestTile";
 import { getDates } from "../../utils/time";
 import { isBefore } from "date-fns";
 import { Dropdown } from "../Dropdown";
@@ -41,7 +41,7 @@ export default function DefaultTemplate({
               updateContestStatus();
           }
           if (contestData.startDate) {
-            const newTimelineObject = getDates(contestData.startDate, contestData.endDate);
+            const newTimelineObject = getDates(contestData.startDate, contestData.endDate, contestData.cohorts);
             setContestTimelineObject(newTimelineObject);
           }
       }
@@ -54,7 +54,7 @@ export default function DefaultTemplate({
           updateBountyStatus();
         }
         if (bountyData.startDate) {
-          const newTimelineObject = getDates(bountyData.startDate, "2999-01-01T00:00:00Z");
+          const newTimelineObject = getDates(bountyData.startDate, "2999-01-01T00:00:00Z", []);
           setBountyTimelineObject(newTimelineObject);
         }
       }
@@ -64,7 +64,8 @@ export default function DefaultTemplate({
       if (bountyData && bountyData.startDate) {
         const newTimelineObject = getDates(
           bountyData.startDate,
-          "2999-01-01T00:00:00Z"
+          "2999-01-01T00:00:00Z",
+          []
         );
         setBountyTimelineObject(newTimelineObject);
       }
@@ -74,7 +75,8 @@ export default function DefaultTemplate({
         if (contestData.startDate && contestData.endDate) {
           const newTimelineObject = getDates(
             contestData.startDate,
-            contestData.endDate
+            contestData.endDate,
+            contestData.cohorts
           );
           setContestTimelineObject(newTimelineObject);
         }
@@ -307,7 +309,7 @@ function IsContest({
                   <h2 className="title">
                     <a
                       href={contestUrl}
-                      onClick={(e) => e.stopPropagation()}  
+                      onClick={(e) => e.stopPropagation()}
                     >
                       {title}
                     </a>
@@ -329,7 +331,7 @@ function IsContest({
                             size={TagSize.NARROW}
                           />
                         )}
-                        {ecosystem && <Tag 
+                        {ecosystem && <Tag
                           variant={isDarkTile ? TagVariant.DEFAULT : TagVariant.WHITE_OUTLINE}
                           label={ecosystem}
                           iconLeft={ecosystemLogoName ? <Icon name={ecosystemLogoName} size="medium" color="white" /> : undefined}
@@ -361,15 +363,9 @@ function IsContest({
           />}
           {contestData && contestTimelineObject && contestTimelineObject.contestStatus !== Status.ENDED && (
               <div className="timer">
-                <Countdown
-                    start={startDate}
-                    end={endDate}
+                <ContestCountdown
+                    schedule={contestTimelineObject}
                     updateContestStatus={updateContestTileStatus}
-                    text={
-                    contestTimelineObject.contestStatus === Status.UPCOMING
-                        ? "Starts in "
-                        : "Ends in "
-                    }
                 />
               </div>
           )}
@@ -467,7 +463,7 @@ function IsBounty({
               <div className="description">
                 {description}
                 {(ecosystem || (languages && languages.length > 0)) && <div className="tags">
-                  {ecosystem && <Tag 
+                  {ecosystem && <Tag
                     variant={isDarkTile ? TagVariant.DEFAULT : TagVariant.WHITE_OUTLINE}
                     label={ecosystem}
                     iconLeft={ecosystemLogoName ? <Icon name={ecosystemLogoName} size="medium" color="white" /> : undefined}

--- a/src/lib/ContestTile/DefaultTemplate.tsx
+++ b/src/lib/ContestTile/DefaultTemplate.tsx
@@ -1,11 +1,11 @@
 import React, { Fragment, useCallback, useEffect, useState } from "react";
 import clsx from "clsx";
 import wolfbotIcon from "../../../public/icons/wolfbot.svg";
-import { BountyTileData, ContestSchedule, ContestTileData, ContestTileProps, ContestTileVariant } from "./ContestTile.types";
+import { BaseContestSchedule, BountyTileData, ContestSchedule, ContestTileData, ContestTileProps, ContestTileVariant } from "./ContestTile.types";
 import { DropdownLink, Status, TagSize, TagVariant } from "../types";
 import { ContestStatus } from "../ContestStatus";
 import { ContestCountdown, Countdown } from "./ContestTile";
-import { getDates } from "../../utils/time";
+import { getDates, getContestSchedule } from "../../utils/time";
 import { isBefore } from "date-fns";
 import { Dropdown } from "../Dropdown";
 import { Icon } from "../Icon";
@@ -32,7 +32,7 @@ export default function DefaultTemplate({
     const [canViewContest, setCanViewContest] = useState(false);
     const [dropdownLinks, setDropdownLinks] = useState<DropdownLink[]>([]);
     const [contestTimelineObject, setContestTimelineObject] = useState<ContestSchedule | undefined>();
-    const [bountyTimelineObject, setBountyTimelineObject] = useState<ContestSchedule | undefined>();
+    const [bountyTimelineObject, setBountyTimelineObject] = useState<BaseContestSchedule | undefined>();
 
     const updateContestTileStatus = useCallback(() => {
       if (contestData) {
@@ -41,7 +41,7 @@ export default function DefaultTemplate({
               updateContestStatus();
           }
           if (contestData.startDate) {
-            const newTimelineObject = getDates(contestData.startDate, contestData.endDate, contestData.cohorts);
+            const newTimelineObject = getContestSchedule(contestData);
             setContestTimelineObject(newTimelineObject);
           }
       }
@@ -54,7 +54,7 @@ export default function DefaultTemplate({
           updateBountyStatus();
         }
         if (bountyData.startDate) {
-          const newTimelineObject = getDates(bountyData.startDate, "2999-01-01T00:00:00Z", []);
+          const newTimelineObject = getDates(bountyData.startDate, "2999-01-01T00:00:00Z");
           setBountyTimelineObject(newTimelineObject);
         }
       }
@@ -64,8 +64,7 @@ export default function DefaultTemplate({
       if (bountyData && bountyData.startDate) {
         const newTimelineObject = getDates(
           bountyData.startDate,
-          "2999-01-01T00:00:00Z",
-          []
+          "2999-01-01T00:00:00Z"
         );
         setBountyTimelineObject(newTimelineObject);
       }
@@ -73,10 +72,8 @@ export default function DefaultTemplate({
       if (contestData) {
         setHasBotRace(!!contestData.botFindingsRepo);
         if (contestData.startDate && contestData.endDate) {
-          const newTimelineObject = getDates(
-            contestData.startDate,
-            contestData.endDate,
-            contestData.cohorts
+          const newTimelineObject = getContestSchedule(
+            contestData
           );
           setContestTimelineObject(newTimelineObject);
         }
@@ -403,7 +400,7 @@ function IsBounty({
   bountyData: BountyTileData;
   isDarkTile: boolean;
   updateBountyTileStatus?: () => void;
-  bountyTimelineObject?: ContestSchedule | undefined;
+  bountyTimelineObject?: BaseContestSchedule | undefined;
 }) {
   const { bountyUrl, amount, startDate, ecosystem, languages } = bountyData;
   const endDate = "2999-01-01T00:00:00Z"

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "@jest/globals";
 import { addHours, format } from "date-fns";
 import { DateTime } from "luxon";
-import { getCurrentCohortDates, getDates } from "./time";
-import { ContestCohort, Status } from "../types";
+import { getContestSchedule, getCurrentCohortDates } from "./time";
+import { AuditStatus, ContestCohort, Status } from "../types";
 
 describe("utils/time", () => {
   describe("getCurrentCohortDates", () => {
@@ -131,7 +131,12 @@ describe("utils/time", () => {
       const start = new Date(Date.now() + 1000);
       const end = new Date(Date.now() + 6000);
 
-      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const dates = getContestSchedule({
+        startDate: start.toISOString(),
+        endDate: end.toISOString(),
+        cohorts,
+        status: AuditStatus.PreAudit
+      });
       const expectedBotRaceEnd = addHours(start, 1);
       expect(dates).toStrictEqual({
         botRaceEnd: expectedBotRaceEnd,
@@ -145,6 +150,7 @@ describe("utils/time", () => {
         pause: new Date(cohorts[0].pauseTime!),
         resume: null,
         start: start,
+        status: AuditStatus.PreAudit,
         timeZone: DateTime.local().toFormat("ZZZZ")
       });
     });
@@ -153,7 +159,12 @@ describe("utils/time", () => {
       const start = new Date(Date.now() + 1000);
       const end = new Date(Date.now() + 6000);
 
-      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const dates = getContestSchedule({
+        startDate: start.toISOString(),
+        endDate: end.toISOString(),
+        cohorts,
+        status: AuditStatus.PreAudit
+      });
       const expectedBotRaceEnd = addHours(start, 1);
       expect(dates).toStrictEqual({
         botRaceEnd: expectedBotRaceEnd,
@@ -167,6 +178,7 @@ describe("utils/time", () => {
         pause: null,
         resume: null,
         start: start,
+        status: AuditStatus.PreAudit,
         timeZone: DateTime.local().toFormat("ZZZZ")
       });
     });
@@ -187,7 +199,12 @@ describe("utils/time", () => {
       const start = new Date(Date.now());
       const end = new Date(Date.now() + 5000);
 
-      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const dates = getContestSchedule({
+        startDate: start.toISOString(),
+        endDate: end.toISOString(),
+        cohorts,
+        status: AuditStatus.Active
+      });
       const expectedBotRaceEnd = addHours(start, 1);
       expect(dates).toStrictEqual({
         botRaceEnd: expectedBotRaceEnd,
@@ -201,6 +218,7 @@ describe("utils/time", () => {
         pause: new Date(cohorts[0].pauseTime!),
         resume: null,
         start: start,
+        status: AuditStatus.Active,
         timeZone: DateTime.local().toFormat("ZZZZ")
       });
     });
@@ -221,7 +239,12 @@ describe("utils/time", () => {
       const start = new Date(Date.now() - 2000);
       const end = new Date(Date.now() + 4000);
 
-      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const dates = getContestSchedule({
+        startDate: start.toISOString(),
+        endDate: end.toISOString(),
+        cohorts,
+        status: AuditStatus.Paused
+      });
       const expectedBotRaceEnd = addHours(start, 1);
       expect(dates).toStrictEqual({
         botRaceEnd: expectedBotRaceEnd,
@@ -235,6 +258,7 @@ describe("utils/time", () => {
         pause: new Date(cohorts[1].pauseTime!),
         resume: new Date(cohorts[1].resumeTime!),
         start: start,
+        status: AuditStatus.Paused,
         timeZone: DateTime.local().toFormat("ZZZZ")
       });
     });
@@ -256,7 +280,12 @@ describe("utils/time", () => {
       const start = new Date(Date.now() - 3000);
       const end = new Date(Date.now() + 3000);
 
-      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const dates = getContestSchedule({
+        startDate: start.toISOString(),
+        endDate: end.toISOString(),
+        cohorts,
+        status: AuditStatus.Active
+      });
       const expectedBotRaceEnd = addHours(start, 1);
       expect(dates).toStrictEqual({
         botRaceEnd: expectedBotRaceEnd,
@@ -270,6 +299,7 @@ describe("utils/time", () => {
         pause: new Date(cohorts[1].pauseTime!),
         resume: new Date(cohorts[1].resumeTime!),
         start: start,
+        status: AuditStatus.Active,
         timeZone: DateTime.local().toFormat("ZZZZ")
       });
     });
@@ -291,7 +321,12 @@ describe("utils/time", () => {
       const start = new Date(Date.now() - 5000);
       const end = new Date(Date.now() + 1000);
 
-      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const dates = getContestSchedule({
+        startDate: start.toISOString(),
+        endDate: end.toISOString(),
+        cohorts,
+        status: AuditStatus.Active
+      });
       const expectedBotRaceEnd = addHours(start, 1);
       expect(dates).toStrictEqual({
         botRaceEnd: expectedBotRaceEnd,
@@ -305,6 +340,7 @@ describe("utils/time", () => {
         pause: null,
         resume: new Date(cohorts[2].resumeTime!),
         start: start,
+        status: AuditStatus.Active,
         timeZone: DateTime.local().toFormat("ZZZZ")
       });
     });
@@ -326,7 +362,12 @@ describe("utils/time", () => {
       const start = new Date(Date.now() - 6000);
       const end = new Date(Date.now() - 1000);
 
-      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const dates = getContestSchedule({
+        startDate: start.toISOString(),
+        endDate: end.toISOString(),
+        cohorts,
+        status: AuditStatus.Review
+      });
       const expectedBotRaceEnd = addHours(start, 1);
       expect(dates).toStrictEqual({
         botRaceEnd: expectedBotRaceEnd,
@@ -340,6 +381,7 @@ describe("utils/time", () => {
         pause: null,
         resume: new Date(cohorts[2].resumeTime!),
         start: start,
+        status: AuditStatus.Review,
         timeZone: DateTime.local().toFormat("ZZZZ")
       });
     });

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, test } from "@jest/globals";
+import { addHours, format } from "date-fns";
+import { DateTime } from "luxon";
+import { getCurrentCohortDates, getDates } from "./time";
+import { ContestCohort, Status } from "../types";
+
+describe("utils/time", () => {
+  describe("getCurrentCohortDates", () => {
+    test("gets the correct, current cohort", () => {
+      // First cohort
+      let cohorts:ContestCohort[] = [{
+        name: "cohort-1",
+        resumeTime: null,
+        pauseTime: new Date(Date.now() + 1000).toISOString(),
+      }, {
+        name: "cohort-2",
+        resumeTime: new Date(Date.now() + 2000).toISOString(),
+        pauseTime: new Date(Date.now() + 3000).toISOString(),
+      }, {
+        name: "cohort-3",
+        resumeTime: new Date(Date.now() + 4000).toISOString(),
+        pauseTime: null,
+      }];
+      let dates = getCurrentCohortDates(cohorts);
+
+      expect(dates).toStrictEqual({
+        resumeDate: null,
+        pauseDate: new Date(cohorts[0].pauseTime!),
+      });
+
+      // Upcoming 2nd cohort
+      cohorts = [{
+        name: "cohort-1",
+        resumeTime: null,
+        pauseTime: new Date(Date.now() - 2000).toISOString(),
+      }, {
+        name: "cohort-2",
+        resumeTime: new Date(Date.now() + 1000).toISOString(),
+        pauseTime: new Date(Date.now() + 2000).toISOString(),
+      }, {
+        name: "cohort-3",
+        resumeTime: new Date(Date.now() + 3000).toISOString(),
+        pauseTime: null,
+      }];
+      dates = getCurrentCohortDates(cohorts);
+
+      expect(dates).toStrictEqual({
+        resumeDate: new Date(cohorts[1].resumeTime!),
+        pauseDate: new Date(cohorts[1].pauseTime!),
+      });
+
+      // Active 2nd cohort
+      cohorts = [{
+        name: "cohort-1",
+        resumeTime: null,
+        pauseTime: new Date(Date.now() - 2000).toISOString(),
+      }, {
+        name: "cohort-2",
+        resumeTime: new Date(Date.now() - 1000).toISOString(),
+        pauseTime: new Date(Date.now() + 2000).toISOString(),
+      }, {
+        name: "cohort-3",
+        resumeTime: new Date(Date.now() + 3000).toISOString(),
+        pauseTime: null,
+      }];
+      dates = getCurrentCohortDates(cohorts);
+
+      expect(dates).toStrictEqual({
+        resumeDate: new Date(cohorts[1].resumeTime!),
+        pauseDate: new Date(cohorts[1].pauseTime!)
+      });
+
+      // Upcoming 3rd
+      cohorts = [{
+        name: "cohort-1",
+        resumeTime: null,
+        pauseTime: new Date(Date.now() - 4000).toISOString(),
+      }, {
+        name: "cohort-2",
+        resumeTime: new Date(Date.now() - 3000).toISOString(),
+        pauseTime: new Date(Date.now() - 1000).toISOString(),
+      }, {
+        name: "cohort-3",
+        resumeTime: new Date(Date.now() + 1000).toISOString(),
+        pauseTime: null,
+      }];
+      dates = getCurrentCohortDates(cohorts);
+
+      expect(dates).toStrictEqual({
+        resumeDate: new Date(cohorts[2].resumeTime!),
+        pauseDate: null,
+      });
+
+      // Active 3rd
+      cohorts = [{
+        name: "cohort-1",
+        resumeTime: null,
+        pauseTime: new Date(Date.now() - 4000).toISOString(),
+      }, {
+        name: "cohort-2",
+        resumeTime: new Date(Date.now() - 3000).toISOString(),
+        pauseTime: new Date(Date.now() - 2000).toISOString(),
+      }, {
+        name: "cohort-3",
+        resumeTime: new Date(Date.now() - 1000).toISOString(),
+        pauseTime: null,
+      }];
+      dates = getCurrentCohortDates(cohorts);
+
+      expect(dates).toStrictEqual({
+        resumeDate: new Date(cohorts[2].resumeTime!),
+        pauseDate: null,
+      });
+    });
+  });
+  describe("getDates", () => {
+    test("gets the correct dates for an upcoming audit", () => {
+      const cohorts = [{
+        name: "cohort-1",
+        resumeTime: null,
+        pauseTime: new Date(Date.now() + 2000).toISOString(),
+      }, {
+        name: "cohort-2",
+        resumeTime: new Date(Date.now() + 3000).toISOString(),
+        pauseTime: new Date(Date.now() + 4000).toISOString(),
+      }, {
+        name: "cohort-3",
+        resumeTime: new Date(Date.now() + 5000).toISOString(),
+        pauseTime: null,
+      }];
+      const start = new Date(Date.now() + 1000);
+      const end = new Date(Date.now() + 6000);
+
+      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const expectedBotRaceEnd = addHours(start, 1);
+      expect(dates).toStrictEqual({
+        botRaceEnd: expectedBotRaceEnd,
+        botRaceStatus: Status.UPCOMING,
+        contestStatus: Status.UPCOMING,
+        end: end,
+        formattedBotRaceEnd: format(expectedBotRaceEnd, "d MMM h:mm a"),
+        formattedDuration: "less than a minute",
+        formattedEnd: format(end, "d MMM h:mm a"),
+        formattedStart: format(start, "d MMM h:mm a"),
+        pause: new Date(cohorts[0].pauseTime!),
+        resume: null,
+        start: start,
+        timeZone: DateTime.local().toFormat("ZZZZ")
+      });
+    });
+    test("gets the correct dates for an audit with no cohorts", () => {
+      const cohorts:ContestCohort[] = [];
+      const start = new Date(Date.now() + 1000);
+      const end = new Date(Date.now() + 6000);
+
+      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const expectedBotRaceEnd = addHours(start, 1);
+      expect(dates).toStrictEqual({
+        botRaceEnd: expectedBotRaceEnd,
+        botRaceStatus: Status.UPCOMING,
+        contestStatus: Status.UPCOMING,
+        end: end,
+        formattedBotRaceEnd: format(expectedBotRaceEnd, "d MMM h:mm a"),
+        formattedDuration: "less than a minute",
+        formattedEnd: format(end, "d MMM h:mm a"),
+        formattedStart: format(start, "d MMM h:mm a"),
+        pause: null,
+        resume: null,
+        start: start,
+        timeZone: DateTime.local().toFormat("ZZZZ")
+      });
+    });
+    test("gets the correct dates for a live audit in cohort 1", () => {
+      const cohorts = [{
+        name: "cohort-1",
+        resumeTime: null,
+        pauseTime: new Date(Date.now() + 1000).toISOString(),
+      }, {
+        name: "cohort-2",
+        resumeTime: new Date(Date.now() + 2000).toISOString(),
+        pauseTime: new Date(Date.now() + 3000).toISOString(),
+      }, {
+        name: "cohort-3",
+        resumeTime: new Date(Date.now() + 4000).toISOString(),
+        pauseTime: null,
+      }];
+      const start = new Date(Date.now());
+      const end = new Date(Date.now() + 5000);
+
+      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const expectedBotRaceEnd = addHours(start, 1);
+      expect(dates).toStrictEqual({
+        botRaceEnd: expectedBotRaceEnd,
+        botRaceStatus: Status.LIVE,
+        contestStatus: Status.LIVE,
+        end: end,
+        formattedBotRaceEnd: format(expectedBotRaceEnd, "d MMM h:mm a"),
+        formattedDuration: "less than a minute",
+        formattedEnd: format(end, "d MMM h:mm a"),
+        formattedStart: format(start, "d MMM h:mm a"),
+        pause: new Date(cohorts[0].pauseTime!),
+        resume: null,
+        start: start,
+        timeZone: DateTime.local().toFormat("ZZZZ")
+      });
+    });
+    test("gets the correct dates for a live audit inbetween cohort 1 and 2", () => {
+      const cohorts = [{
+        name: "cohort-1",
+        resumeTime: null,
+        pauseTime: new Date(Date.now() - 1000).toISOString(),
+      }, {
+        name: "cohort-2",
+        resumeTime: new Date(Date.now() + 1000).toISOString(),
+        pauseTime: new Date(Date.now() + 2000).toISOString(),
+      }, {
+        name: "cohort-3",
+        resumeTime: new Date(Date.now() + 3000).toISOString(),
+        pauseTime: null,
+      }];
+      const start = new Date(Date.now() - 2000);
+      const end = new Date(Date.now() + 4000);
+
+      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const expectedBotRaceEnd = addHours(start, 1);
+      expect(dates).toStrictEqual({
+        botRaceEnd: expectedBotRaceEnd,
+        botRaceStatus: Status.LIVE,
+        contestStatus: Status.LIVE,
+        end: end,
+        formattedBotRaceEnd: format(expectedBotRaceEnd, "d MMM h:mm a"),
+        formattedDuration: "less than a minute",
+        formattedEnd: format(end, "d MMM h:mm a"),
+        formattedStart: format(start, "d MMM h:mm a"),
+        pause: new Date(cohorts[1].pauseTime!),
+        resume: new Date(cohorts[1].resumeTime!),
+        start: start,
+        timeZone: DateTime.local().toFormat("ZZZZ")
+      });
+    });
+
+    test("gets the correct dates for a live audit in cohort 2", () => {
+      const cohorts = [{
+        name: "cohort-1",
+        resumeTime: null,
+        pauseTime: new Date(Date.now() - 2000).toISOString(),
+      }, {
+        name: "cohort-2",
+        resumeTime: new Date(Date.now() - 1000).toISOString(),
+        pauseTime: new Date(Date.now() + 1000).toISOString(),
+      }, {
+        name: "cohort-3",
+        resumeTime: new Date(Date.now() + 2000).toISOString(),
+        pauseTime: null,
+      }];
+      const start = new Date(Date.now() - 3000);
+      const end = new Date(Date.now() + 3000);
+
+      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const expectedBotRaceEnd = addHours(start, 1);
+      expect(dates).toStrictEqual({
+        botRaceEnd: expectedBotRaceEnd,
+        botRaceStatus: Status.LIVE,
+        contestStatus: Status.LIVE,
+        end: end,
+        formattedBotRaceEnd: format(expectedBotRaceEnd, "d MMM h:mm a"),
+        formattedDuration: "less than a minute",
+        formattedEnd: format(end, "d MMM h:mm a"),
+        formattedStart: format(start, "d MMM h:mm a"),
+        pause: new Date(cohorts[1].pauseTime!),
+        resume: new Date(cohorts[1].resumeTime!),
+        start: start,
+        timeZone: DateTime.local().toFormat("ZZZZ")
+      });
+    });
+
+    test("gets the correct dates for a live audit in cohort 3", () => {
+      const cohorts = [{
+        name: "cohort-1",
+        resumeTime: null,
+        pauseTime: new Date(Date.now() - 4000).toISOString(),
+      }, {
+        name: "cohort-2",
+        resumeTime: new Date(Date.now() - 3000).toISOString(),
+        pauseTime: new Date(Date.now() - 2000).toISOString(),
+      }, {
+        name: "cohort-3",
+        resumeTime: new Date(Date.now() - 1000).toISOString(),
+        pauseTime: null,
+      }];
+      const start = new Date(Date.now() - 5000);
+      const end = new Date(Date.now() + 1000);
+
+      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const expectedBotRaceEnd = addHours(start, 1);
+      expect(dates).toStrictEqual({
+        botRaceEnd: expectedBotRaceEnd,
+        botRaceStatus: Status.LIVE,
+        contestStatus: Status.LIVE,
+        end: end,
+        formattedBotRaceEnd: format(expectedBotRaceEnd, "d MMM h:mm a"),
+        formattedDuration: "less than a minute",
+        formattedEnd: format(end, "d MMM h:mm a"),
+        formattedStart: format(start, "d MMM h:mm a"),
+        pause: null,
+        resume: new Date(cohorts[2].resumeTime!),
+        start: start,
+        timeZone: DateTime.local().toFormat("ZZZZ")
+      });
+    });
+
+    test("gets the correct dates for a finished contest", () => {
+      const cohorts = [{
+        name: "cohort-1",
+        resumeTime: null,
+        pauseTime: new Date(Date.now() - 5000).toISOString(),
+      }, {
+        name: "cohort-2",
+        resumeTime: new Date(Date.now() - 4000).toISOString(),
+        pauseTime: new Date(Date.now() - 3000).toISOString(),
+      }, {
+        name: "cohort-3",
+        resumeTime: new Date(Date.now() - 2000).toISOString(),
+        pauseTime: null,
+      }];
+      const start = new Date(Date.now() - 6000);
+      const end = new Date(Date.now() - 1000);
+
+      const dates = getDates(start.toISOString(), end.toISOString(), cohorts);
+      const expectedBotRaceEnd = addHours(start, 1);
+      expect(dates).toStrictEqual({
+        botRaceEnd: expectedBotRaceEnd,
+        botRaceStatus: Status.ENDED,
+        contestStatus: Status.ENDED,
+        end: end,
+        formattedBotRaceEnd: format(expectedBotRaceEnd, "d MMM h:mm a"),
+        formattedDuration: "less than a minute",
+        formattedEnd: format(end, "d MMM h:mm a"),
+        formattedStart: format(start, "d MMM h:mm a"),
+        pause: null,
+        resume: new Date(cohorts[2].resumeTime!),
+        start: start,
+        timeZone: DateTime.local().toFormat("ZZZZ")
+      });
+    });
+  });
+});

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,6 +1,7 @@
 import { addHours, format, formatDistance, isAfter, isBefore, isEqual } from "date-fns";
-import { ContestCohort, ContestSchedule } from "../lib/ContestTile/ContestTile.types";
-import { Status } from "../lib/ContestStatus/ContestStatus.types";
+import { BaseContestSchedule, ContestCohort, ContestSchedule } from "../lib/ContestTile/ContestTile.types";
+import { AuditStatus, Status } from "../lib/ContestStatus/ContestStatus.types";
+import { ContestTileData } from "../lib/ContestTile/ContestTile.types";
 import { DateTime } from "luxon";
 
 function getContestStatuses(
@@ -56,7 +57,24 @@ const getCurrentCohortDates = (cohorts: ContestCohort[]) => {
   }
 };
 
-const getDates = (start: string, end: string, cohorts: ContestCohort[]): ContestSchedule => {
+const getContestSchedule = (
+  contest: Pick<ContestTileData, "cohorts" | "endDate" | "startDate" | "status">
+): ContestSchedule => {
+  const schedule = getDates(contest.startDate, contest.endDate);
+  const currentCohort = getCurrentCohortDates(contest.cohorts);
+
+  return {
+    ...schedule,
+    pause: currentCohort.pauseDate && new Date(currentCohort.pauseDate),
+    resume: currentCohort.resumeDate && new Date(currentCohort.resumeDate),
+    status: contest.status,
+  };
+}
+
+const getDates = (
+  start: string,
+  end: string
+): BaseContestSchedule => {
   const startDate = new Date(start);
   const endDate = new Date(end);
   const timeZone = DateTime.local().toFormat("ZZZZ");
@@ -68,15 +86,11 @@ const getDates = (start: string, end: string, cohorts: ContestCohort[]): Contest
     botRaceEnd
   );
 
-  const currentCohort = getCurrentCohortDates(cohorts);
-
   return {
     contestStatus,
     botRaceStatus,
     start: startDate,
     end: endDate,
-    pause: currentCohort.pauseDate && new Date(currentCohort.pauseDate),
-    resume: currentCohort.resumeDate && new Date(currentCohort.resumeDate),
     botRaceEnd,
     formattedEnd: format(endDate, "d MMM h:mm a"),
     formattedStart: format(startDate, "d MMM h:mm a"),
@@ -86,4 +100,4 @@ const getDates = (start: string, end: string, cohorts: ContestCohort[]): Contest
   };
 };
 
-export { getDates, getCurrentCohortDates };
+export { getDates, getContestSchedule, getCurrentCohortDates };

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,6 +1,6 @@
 import { addHours, format, formatDistance, isAfter, isBefore, isEqual } from "date-fns";
 import { BaseContestSchedule, ContestCohort, ContestSchedule } from "../lib/ContestTile/ContestTile.types";
-import { AuditStatus, Status } from "../lib/ContestStatus/ContestStatus.types";
+import { Status } from "../lib/ContestStatus/ContestStatus.types";
 import { ContestTileData } from "../lib/ContestTile/ContestTile.types";
 import { DateTime } from "luxon";
 


### PR DESCRIPTION
## Summary

* ContestSchedule now includes a cohort array, which is used by the ContestTile
* Added a new component, `ContestCountdown`, that wraps the Countdown component and only requires a ContestSchedule and the optional click handler. It will automatically handle the language selection that's usually owned by the parent component and repeated in multiple places.
  * The Countdown component is backwards compatible, so it can still be used as it is today
* Updated Storybook to show the various states of cohorts to make it easier to see how those transitions will look
* Fixed an issue with the getDates logic when Date.now equals the start date of an audit. This resulted in undefined times being returned. The newly added tests caught this and validate the fix.

## References
* Resolves https://app.clickup.com/t/9015711866/DEV-408