### PR TITLE
[Compact contest tile] mobile responsive changes

### DIFF
--- a/src/lib/ContestTile/ContestTile.scss
+++ b/src/lib/ContestTile/ContestTile.scss
@@ -375,8 +375,6 @@
                     header {
                         .header--status {
                             display: flex;
-                            flex-wrap: wrap;
-                            align-items: center;
                             justify-content: space-between;
                             column-gap: 1.5rem;
                             row-gap: 0.5rem;
@@ -404,11 +402,9 @@
                                 }
     
                                 &.type {
-                                    min-width: auto;
-                                    margin-left: auto;
-                                    overflow: hidden;
-                                    text-overflow: ellipsis;
-                                    white-space: nowrap;
+                                    flex-grow: 0; // Prevent the type element from growing
+                                    flex-shrink: 0; // Prevent the type element from shrinking
+                                    white-space: nowrap; // Prevent text from wrapping
                                 }
                             }
                         }
@@ -813,6 +809,17 @@
                     }
                 }
             }
+        }
+    }
+}
+
+// Compact tile overrides
+.c4contesttile.compact {
+    .c4conteststatus {
+        align-items: start;
+
+        .statusindicator {
+            margin-top: 8px;
         }
     }
 }


### PR DESCRIPTION
- changes the top status row of the compact variant of the audit tile to look a little better on the eyes on smaller columns and mobile devices

solves: https://app.clickup.com/t/9015711866/DEV-456

after:
![image](https://github.com/user-attachments/assets/abb9e8a0-dd72-4735-93ad-891fb9fc3c81)
