### PR TITLE
types: audit status may be null

### DIFF
--- a/src/lib/ContestStatus/ContestStatus.types.ts
+++ b/src/lib/ContestStatus/ContestStatus.types.ts
@@ -20,6 +20,7 @@ export const AuditStatus = {
   /** Paused: The audit is in between Rolling Triage cohorts */
   Paused: "Paused",
   Review: "Review",
+  Restricted: "Restricted",
   Judging: "Judging",
   PJQA: "Post-Judging QA",
   JudgingComplete: "Judging Complete",

--- a/src/lib/ContestTile/ContestTile.types.ts
+++ b/src/lib/ContestTile/ContestTile.types.ts
@@ -87,7 +87,7 @@ export interface ContestTileData {
   endDate: string;
   /** Boolean indicating certification status of logged in user. Required for viewing certain contests. */
   isUserCertified: boolean;
-  status: AuditStatus;
+  status: AuditStatus | null;
 }
 
 export interface BaseContestSchedule {
@@ -104,7 +104,7 @@ export interface BaseContestSchedule {
 }
 
 export interface ContestSchedule extends BaseContestSchedule {
-  status: AuditStatus;
+  status: AuditStatus | null;
   end: Date;
   /** The time the current cohort will pause. */
   pause: Date | null;


### PR DESCRIPTION
## Summary

The status of an audit may be null. There are 103 audits in prod that don't currently have a status (various legacy audits that existed before we started using it).

This updates the types to allow for that, which will help ensure we're handling that correctly downstream.